### PR TITLE
Fix PropTypes.Object parsing and code generating

### DIFF
--- a/src/__tests__/ast.test.ts
+++ b/src/__tests__/ast.test.ts
@@ -190,6 +190,7 @@ describe('parseCode', () => {
           >
             <Input
               value={value}
+              obj={{ foo: true }}
               onChange={e => setValue(e.target.value)}
               placeholder="Controlled Input"
             />
@@ -203,6 +204,7 @@ describe('parseCode', () => {
         onChange: 'e => setValue(e.target.value)',
         placeholder: 'Controlled Input',
         value: 'Hello',
+        obj: '{ foo: true }',
       },
       parsedProvider: {
         inputFill: 'yellow',

--- a/src/__tests__/code-generator.test.ts
+++ b/src/__tests__/code-generator.test.ts
@@ -245,29 +245,25 @@ describe('getAstPropValue', () => {
         {}
       )
     ).toEqual({
-      body: [
+      properties: [
         {
-          body: {
-            expression: {
-              loc: undefined,
-              type: 'BooleanLiteral',
-              value: true,
-            },
-            loc: undefined,
-            type: 'ExpressionStatement',
-          },
-          label: {
+          computed: false,
+          key: {
             loc: undefined,
             name: 'foo',
             type: 'Identifier',
           },
           loc: undefined,
-          type: 'LabeledStatement',
+          shorthand: false,
+          type: 'ObjectProperty',
+          value: {
+            loc: undefined,
+            type: 'BooleanLiteral',
+            value: true,
+          },
         },
       ],
-      directives: [],
-      loc: undefined,
-      type: 'BlockStatement',
+      type: 'ObjectExpression',
     });
   });
   test('React node', () => {

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -157,6 +157,11 @@ export function parseCode(
                     t.program([t.expressionStatement(attr.value.expression)]),
                     30
                   );
+                  if (attr.value.expression.type === 'ObjectExpression') {
+                    // the generated code is ({ .... }), this removes the brackets to
+                    // keep the input more readable
+                    value = value.slice(1, -1);
+                  }
                 }
               }
             }

--- a/src/code-generator.ts
+++ b/src/code-generator.ts
@@ -53,7 +53,9 @@ export const getAstPropValue = (
     case PropTypes.Ref:
       return null;
     case PropTypes.Object:
-      return template.ast(`${value}`, {plugins: ['jsx']}) as any;
+      // need to add this bogus assignment so the value is recognized as an ObjectExpression
+      return (template.ast(`a = ${value}`, {plugins: ['jsx']}) as any)
+        .expression.right;
     case PropTypes.Array:
     case PropTypes.Number:
     case PropTypes.Function:


### PR DESCRIPTION
Fixes: https://github.com/uber/react-view/issues/8

It wasn't recognized as an ObjectExpression since `{...}` is by default a BlockStatement.