### PR TITLE
add support for enum keys with a dash

### DIFF
--- a/src/__tests__/ast.test.ts
+++ b/src/__tests__/ast.test.ts
@@ -191,6 +191,8 @@ describe('parseCode', () => {
             <Input
               value={value}
               obj={{ foo: true }}
+              size={SIZE['a-b']}
+              size2={SIZE.a}
               onChange={e => setValue(e.target.value)}
               placeholder="Controlled Input"
             />
@@ -204,6 +206,8 @@ describe('parseCode', () => {
         onChange: 'e => setValue(e.target.value)',
         placeholder: 'Controlled Input',
         value: 'Hello',
+        size: 'SIZE.a-b',
+        size2: 'SIZE.a',
         obj: '{ foo: true }',
       },
       parsedProvider: {

--- a/src/__tests__/code-generator.test.ts
+++ b/src/__tests__/code-generator.test.ts
@@ -189,8 +189,40 @@ describe('getAstPropValue', () => {
         {}
       )
     ).toEqual({
-      name: 'SIZE.large',
-      type: 'Identifier',
+      computed: false,
+      object: {
+        name: 'SIZE',
+        type: 'Identifier',
+      },
+      optional: null,
+      property: {
+        name: 'large',
+        type: 'Identifier',
+      },
+      type: 'MemberExpression',
+    });
+    expect(
+      getAstPropValue(
+        {
+          value: 'SIZE.large-size',
+          type: PropTypes.Enum,
+          description: '',
+        },
+        'foo',
+        {}
+      )
+    ).toEqual({
+      computed: true,
+      object: {
+        name: 'SIZE',
+        type: 'Identifier',
+      },
+      optional: null,
+      property: {
+        value: 'large-size',
+        type: 'StringLiteral',
+      },
+      type: 'MemberExpression',
     });
   });
   test('ref', () => {

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -162,6 +162,14 @@ export function parseCode(
                     // keep the input more readable
                     value = value.slice(1, -1);
                   }
+                  if (
+                    attr.value.expression.type === 'MemberExpression' &&
+                    attr.value.expression.computed
+                  ) {
+                    // turn a['hello-world'] into a.hello-world so we don't have to deal with two
+                    // variants in the enum knob UI
+                    value = `${attr.value.expression.object.name}.${attr.value.expression.property.value}`;
+                  }
                 }
               }
             }

--- a/src/code-generator.ts
+++ b/src/code-generator.ts
@@ -44,7 +44,14 @@ export const getAstPropValue = (
     case PropTypes.Boolean:
       return t.booleanLiteral(Boolean(value));
     case PropTypes.Enum:
-      return t.identifier(String(value));
+      const [object, property] = String(value).split('.');
+      return t.memberExpression(
+        t.identifier(object),
+        property.includes('-')
+          ? t.stringLiteral(property)
+          : t.identifier(property),
+        property.includes('-') ? true : false
+      );
     case PropTypes.Date:
       return t.newExpression(
         t.identifier('Date'),


### PR DESCRIPTION
Fixes https://github.com/uber/react-view/issues/9

It now considers only `-` as a condition to use `a['foo']` notation instead of `a.foo`. There are probably more characters but this should be the only major / real-world usage case.