### PR TITLE
Add all parser flags and prefer typescript over flow

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -14,7 +14,37 @@ import {getAstJsxElement, formatAstAndPrint} from './code-generator';
 export const parse = (code: string) =>
   babelParse(code, {
     sourceType: 'module',
-    plugins: ['jsx', 'flow'],
+    plugins: [
+      'jsx',
+      'flowComments',
+      'typescript',
+      'asyncGenerators',
+      'classProperties',
+      'classPrivateProperties',
+      'classPrivateMethods',
+      [
+        'decorators',
+        {
+          decoratorsBeforeExport: true,
+        },
+      ],
+      'doExpressions',
+      'dynamicImport',
+      'exportDefaultFrom',
+      'exportNamespaceFrom',
+      'functionBind',
+      'functionSent',
+      'importMeta',
+      'logicalAssignment',
+      'nullishCoalescingOperator',
+      'numericSeparator',
+      'objectRestSpread',
+      'optionalCatchBinding',
+      'optionalChaining',
+      'partialApplication',
+      'throwExpressions',
+      'topLevelAwait',
+    ],
   });
 
 // creates a call expression that synchronizes view state


### PR DESCRIPTION
Fixes https://github.com/uber/react-view/issues/7

Well, first I was adding a new API but why not to just enable them all so users don't have to think about it (they still need to keep adding transform plugins tho to compile these features away).

Also flow and typescript can't be used at the same time, so preferring typescript since flow, uhm, is not that common these days and the syntax is almost identical anyway so flow will still mostly work.