### PR TITLE
Enum without imports outputs StringLiteral instead of MemberExpression

### DIFF
--- a/src/__tests__/code-generator.test.ts
+++ b/src/__tests__/code-generator.test.ts
@@ -184,6 +184,11 @@ describe('getAstPropValue', () => {
           value: 'SIZE.large',
           type: PropTypes.Enum,
           description: '',
+          imports: {
+            'your-button-component': {
+              named: ['SIZE'],
+            },
+          },
         },
         'foo',
         {}
@@ -207,6 +212,11 @@ describe('getAstPropValue', () => {
           value: 'SIZE.large-size',
           type: PropTypes.Enum,
           description: '',
+          imports: {
+            'your-button-component': {
+              named: ['SIZE'],
+            },
+          },
         },
         'foo',
         {}
@@ -223,6 +233,20 @@ describe('getAstPropValue', () => {
         type: 'StringLiteral',
       },
       type: 'MemberExpression',
+    });
+    expect(
+      getAstPropValue(
+        {
+          value: 'compact',
+          type: PropTypes.Enum,
+          description: '',
+        },
+        'foo',
+        {}
+      )
+    ).toEqual({
+      value: 'compact',
+      type: 'StringLiteral',
     });
   });
   test('ref', () => {

--- a/src/code-generator.ts
+++ b/src/code-generator.ts
@@ -44,6 +44,9 @@ export const getAstPropValue = (
     case PropTypes.Boolean:
       return t.booleanLiteral(Boolean(value));
     case PropTypes.Enum:
+      if (!prop.imports) {
+        return t.stringLiteral(String(value));
+      }
       const [object, property] = String(value).split('.');
       return t.memberExpression(
         t.identifier(object),

--- a/src/ui/knob.tsx
+++ b/src/ui/knob.tsx
@@ -6,7 +6,14 @@ LICENSE file in the root directory of this source tree.
 */
 import * as React from 'react';
 import Popover from '@miksu/react-tiny-popover';
-import {useValueDebounce, PropTypes, Error, Editor, TPropValue} from '../index';
+import {
+  useValueDebounce,
+  PropTypes,
+  Error,
+  Editor,
+  TPropValue,
+  TImportsConfig,
+} from '../index';
 import {useHover} from '../utils';
 
 const getTooltip = (description: string, type: string, name: string) => (
@@ -117,6 +124,7 @@ const Knob: React.SFC<{
   options?: {[key: string]: string};
   placeholder?: string;
   enumName?: string;
+  imports?: TImportsConfig;
 }> = ({
   name,
   error,
@@ -127,6 +135,7 @@ const Knob: React.SFC<{
   description,
   placeholder,
   enumName,
+  imports,
 }) => {
   const [val] = useValueDebounce<TPropValue>(globalVal, globalSet);
   switch (type) {
@@ -168,29 +177,34 @@ const Knob: React.SFC<{
           <Label tooltip={getTooltip(description, type, name)}>{name}</Label>
           {numberOfOptions < 7 ? (
             <div style={{display: 'flex', flexWrap: 'wrap'}}>
-              {Object.keys(options).map(opt => (
-                <div
-                  style={{
-                    marginRight: '16px',
-                    marginBottom: '8px',
-                    display: 'flex',
-                    alignItems: 'center',
-                  }}
-                  key={opt}
-                >
-                  <input
-                    style={{marginRight: '8px', marginLeft: '0px'}}
-                    type="radio"
-                    checked={`${enumName || name.toUpperCase()}.${opt}` === val}
+              {Object.keys(options).map(opt => {
+                const enumValue = imports
+                  ? `${enumName || name.toUpperCase()}.${opt}`
+                  : opt;
+                return (
+                  <div
+                    style={{
+                      marginRight: '16px',
+                      marginBottom: '8px',
+                      display: 'flex',
+                      alignItems: 'center',
+                    }}
                     key={opt}
-                    id={`${name}_${opt}`}
-                    value={`${enumName || name.toUpperCase()}.${opt}`}
-                    name={`radio_${name}`}
-                    onChange={e => globalSet(e.target.value)}
-                  />
-                  <label htmlFor={`${name}_${opt}`}>{opt}</label>
-                </div>
-              ))}
+                  >
+                    <input
+                      style={{marginRight: '8px', marginLeft: '0px'}}
+                      type="radio"
+                      checked={enumValue === val}
+                      key={opt}
+                      id={`${name}_${opt}`}
+                      value={enumValue}
+                      name={`radio_${name}`}
+                      onChange={e => globalSet(e.target.value)}
+                    />
+                    <label htmlFor={`${name}_${opt}`}>{opt}</label>
+                  </div>
+                );
+              })}
             </div>
           ) : (
             <select

--- a/src/ui/knobs.tsx
+++ b/src/ui/knobs.tsx
@@ -33,6 +33,7 @@ const KnobColumn: React.FC<TKnobsProps & {knobNames: string[]}> = ({
           placeholder={state[name].placeholder}
           set={(value: TPropValue) => set(value, name)}
           enumName={state[name].enumName}
+          imports={state[name].imports}
         />
       ))}
     </div>


### PR DESCRIPTION
Fixes https://github.com/uber/react-view/issues/6 

Folks using union types instead of enums but still want to leverage the enum knob with options to select.

If you don't specify imports for an enum prop, the output will be a string since there is nothing to import and there is no object/constant. 

 