### PR TITLE
Add className prop to basic UI components

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,7 +502,7 @@ className?: string;
 ```
 
 - `isPopup` - Should the component be displayed as a pop-up instead of being inlined.
-- `className` - The class name passed to the root wrapper of Editor.
+- `className` - The class name passed to the root wrapper of Error.
 
 ### Other React View Exports
 

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ compilerProps: {
   code: string;
   setError: (error: string | null) => void;
   transformations: ((ast: t.File) => t.File)[];
+  className?: string;
 }
 ```
 
@@ -384,6 +385,7 @@ editorProps: {
   code: string;
   onChange: (code: string) => void;
   placeholder?: string;
+  className?: string;
 };
 ```
 
@@ -401,6 +403,7 @@ You can pass these props into the `Error` component.
 errorProps: {
   msg: string | null;
   code?: string;
+  className?: string;
 };
 ```
 
@@ -468,11 +471,13 @@ Their APIs almost exactly match the return parameters of `useView`. However, **t
 minHeight?: number;
 placeholder?: React.FC<{height: number}>;
 presets?: PluginItem[];
+className?: string;
 ```
 
 - `minHeight` - To prevent the scroll jump when the component is rendered for the first time (aka the code is executed), we can pre-allocate a container with the `minHeight` (px).
 - `placeholder` - A React component to display before the first render, you can use the default `Placeholder` component (it's a spinner). It gets the `minHeight` through the `height` prop.
 - `presets` - The Compiler component uses Babel and you can add additional babel presets to enable extra syntax features like TypeScript. `preset-react` is included by default.
+- `className` - The class name passed to the root wrapper of Compiler.
 
 #### Editor
 
@@ -481,19 +486,23 @@ language?: 'javascript' | 'jsx' | 'typescript' | 'tsx' | 'css';
 small?: boolean;
 theme?: typeof lightTheme;
 ['data-testid']?: string;
+className?: string;
 ```
 
 - `language` - Syntax highlighting option. `jsx` is used by default.
 - `small` - More compact version of the editor, used as a part of the Knobs UI.
 - `theme` - prism-react-renderer's [theme](https://github.com/FormidableLabs/prism-react-renderer#theming), an internal light theme is used by default (also exported).
+- `className` - The class name passed to the root wrapper of Editor.
 
 #### Error
 
 ```ts
   isPopup?: boolean;
+  className?: string;
 ```
 
 - `isPopup` - Should the component be displayed as a pop-up instead of being inlined.
+- `className` - The class name passed to the root wrapper of Editor.
 
 ### Other React View Exports
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,7 +57,7 @@ export type TCompilerProps = {
   transformations: ((ast: t.File) => t.File)[];
   placeholder?: React.FC<{height: number}>;
   presets?: PluginItem[];
-  classNames?: {[key: string]: string};
+  className?: string;
 };
 
 export type TKnobsProps = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,7 @@ export type TUseViewParams<CustomPropFields = any> = {
   initialCode?: string;
   provider?: TProvider;
   customProps?: TCustomProps;
+  className?: string;
 };
 
 export type TCompilerProps = {
@@ -56,6 +57,7 @@ export type TCompilerProps = {
   transformations: ((ast: t.File) => t.File)[];
   placeholder?: React.FC<{height: number}>;
   presets?: PluginItem[];
+  classNames?: {[key: string]: string};
 };
 
 export type TKnobsProps = {
@@ -73,12 +75,14 @@ export type TEditorProps = {
   small?: boolean;
   theme?: typeof lightTheme;
   ['data-testid']?: string;
+  className?: string;
 };
 
 export type TErrorProps = {
   msg: string | null;
   code?: string;
   isPopup?: boolean;
+  className?: string;
 };
 
 export type TUseView = <ProviderValue = any, CustomPropFields = any>(

--- a/src/ui/action-buttons.tsx
+++ b/src/ui/action-buttons.tsx
@@ -5,6 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 import * as React from 'react';
+import {getStyles} from '../utils';
 
 export const ActionButton: React.FC<{
   onClick: () => void;
@@ -18,7 +19,8 @@ export const ActionButtons: React.FC<{
   copyCode: () => void;
   copyUrl: () => void;
   reset: () => void;
-}> = ({formatCode, copyCode, copyUrl, reset}) => (
+  className?: string;
+}> = ({formatCode, copyCode, copyUrl, reset, className}) => (
   <React.Fragment>
     <style
       dangerouslySetInnerHTML={{
@@ -46,7 +48,7 @@ export const ActionButtons: React.FC<{
   `,
       }}
     />
-    <div style={{margin: '10px 0px'}}>
+    <div {...getStyles({margin: '10px 0px'}, className)}>
       <ActionButton
         data-testid="rv-format"
         style={{marginRight: '8px'}}

--- a/src/ui/compiler.tsx
+++ b/src/ui/compiler.tsx
@@ -11,6 +11,7 @@ import * as t from '@babel/types';
 import presetReact from '@babel/preset-react';
 import {parse} from '../ast';
 import {TCompilerProps} from '../index';
+import {getStyles} from '../utils';
 
 const errorBoundary = (
   Element: React.FC | React.ComponentClass | undefined,
@@ -98,6 +99,7 @@ const Compiler: React.FC<TCompilerProps> = ({
   placeholder,
   minHeight,
   presets,
+  classNames,
 }) => {
   const [output, setOutput] = React.useState<{
     component: React.ComponentClass | null;
@@ -111,18 +113,24 @@ const Compiler: React.FC<TCompilerProps> = ({
   const Placeholder = placeholder;
   return (
     <div
-      style={{
-        minHeight: `${minHeight || 0}px`,
-        paddingTop: minHeight ? '16px' : 0,
-        paddingBottom: minHeight ? '16px' : 0,
-      }}
+      {...getStyles(
+        {
+          minHeight: `${minHeight || 0}px`,
+          paddingTop: minHeight ? '16px' : 0,
+          paddingBottom: minHeight ? '16px' : 0,
+        },
+        classNames && classNames.root
+      )}
     >
       <div
-        style={{
-          display: 'flex',
-          justifyContent: 'center',
-          flexWrap: 'wrap',
-        }}
+        {...getStyles(
+          {
+            display: 'flex',
+            justifyContent: 'center',
+            flexWrap: 'wrap',
+          },
+          classNames && classNames.inner
+        )}
       >
         {Element ? (
           <Element />

--- a/src/ui/compiler.tsx
+++ b/src/ui/compiler.tsx
@@ -99,7 +99,7 @@ const Compiler: React.FC<TCompilerProps> = ({
   placeholder,
   minHeight,
   presets,
-  classNames,
+  className,
 }) => {
   const [output, setOutput] = React.useState<{
     component: React.ComponentClass | null;
@@ -115,29 +115,22 @@ const Compiler: React.FC<TCompilerProps> = ({
     <div
       {...getStyles(
         {
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'baseline',
+          flexWrap: 'wrap',
           minHeight: `${minHeight || 0}px`,
           paddingTop: minHeight ? '16px' : 0,
           paddingBottom: minHeight ? '16px' : 0,
         },
-        classNames && classNames.root
+        className
       )}
     >
-      <div
-        {...getStyles(
-          {
-            display: 'flex',
-            justifyContent: 'center',
-            flexWrap: 'wrap',
-          },
-          classNames && classNames.inner
-        )}
-      >
-        {Element ? (
-          <Element />
-        ) : Placeholder ? (
-          <Placeholder height={minHeight || 32} />
-        ) : null}
-      </div>
+      {Element ? (
+        <Element />
+      ) : Placeholder ? (
+        <Placeholder height={minHeight || 32} />
+      ) : null}
     </div>
   );
 };

--- a/src/ui/editor.tsx
+++ b/src/ui/editor.tsx
@@ -14,6 +14,7 @@ import {
   TEditorLanguage,
   TTransformToken,
 } from '../index';
+import {getStyles} from '../utils';
 
 const highlightCode = ({
   code,
@@ -59,6 +60,7 @@ const Editor: React.FC<TEditorProps> = ({
   language,
   theme,
   ['data-testid']: testid,
+  className,
 }) => {
   const [focused, setFocused] = React.useState(false);
   const editorTheme = {
@@ -74,15 +76,18 @@ const Editor: React.FC<TEditorProps> = ({
   return (
     <div
       data-testid={testid}
-      style={{
-        boxSizing: 'border-box',
-        paddingLeft: '4px',
-        paddingRight: '4px',
-        maxWidth: 'auto',
-        overflow: 'hidden',
-        border: focused ? '1px solid #276EF1' : '1px solid #CCC',
-        borderRadius: '5px',
-      }}
+      {...getStyles(
+        {
+          boxSizing: 'border-box',
+          paddingLeft: '4px',
+          paddingRight: '4px',
+          maxWidth: 'auto',
+          overflow: 'hidden',
+          border: focused ? '1px solid #276EF1' : '1px solid #CCC',
+          borderRadius: '5px',
+        },
+        className
+      )}
     >
       <style
         dangerouslySetInnerHTML={{

--- a/src/ui/error.tsx
+++ b/src/ui/error.tsx
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 import * as React from 'react';
 import Popover from '@miksu/react-tiny-popover';
-import {formatBabelError, frameError} from '../utils';
+import {formatBabelError, frameError, getStyles} from '../utils';
 import {TErrorProps} from '../index';
 
 const PopupError: React.FC<{enabled: boolean; children: React.ReactNode}> = ({
@@ -25,22 +25,25 @@ const PopupError: React.FC<{enabled: boolean; children: React.ReactNode}> = ({
   );
 };
 
-const Error: React.FC<TErrorProps> = ({msg, code, isPopup}) => {
+const Error: React.FC<TErrorProps> = ({msg, code, isPopup, className}) => {
   if (msg === null) return null;
   return (
     <PopupError enabled={Boolean(isPopup)}>
       <div
-        style={{
-          borderRadius: '5px',
-          backgroundColor: '#892C21',
-          whiteSpace: 'pre',
-          fontSize: '11px',
-          fontFamily: `Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace`,
-          color: '#FFF',
-          padding: '16px',
-          margin: `${isPopup ? 4 : 8}px 0px`,
-          overflowX: 'scroll',
-        }}
+        {...getStyles(
+          {
+            borderRadius: '5px',
+            backgroundColor: '#892C21',
+            whiteSpace: 'pre',
+            fontSize: '11px',
+            fontFamily: `Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace`,
+            color: '#FFF',
+            padding: '16px',
+            margin: `${isPopup ? 4 : 8}px 0px`,
+            overflowX: 'scroll',
+          },
+          className
+        )}
       >
         {code ? frameError(msg, code) : formatBabelError(msg)}
       </div>

--- a/src/ui/view.tsx
+++ b/src/ui/view.tsx
@@ -14,13 +14,14 @@ import {
   ActionButtons,
   Placeholder,
 } from '../index';
+import {getStyles} from '../utils';
 
 import {TUseViewParams} from '../types';
 
 const View: React.FC<TUseViewParams> = args => {
   const params = useView(args);
   return (
-    <div style={{maxWidth: '600px'}}>
+    <div {...getStyles({maxWidth: '600px'}, args.className)}>
       <Compiler
         {...params.compilerProps}
         minHeight={62}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -138,3 +138,7 @@ export function clone<T>(obj: T): T {
   }
   return result;
 }
+
+export function getStyles(style: React.CSSProperties, className?: string) {
+  return className ? {className} : {style};
+}


### PR DESCRIPTION
I've decided to create a tiny helper function `getStyles` which would either use the currently defined inline styles, or the className passed.

IMO, it would probably make overriding simpler if we had stylesheets, instead of inline styles, but I think this is good enough for now. Might be worth considering in the future if styles become more complex.

Closes #14