### PR TITLE
Make copy to URL feature work in Storybook

### DIFF
--- a/src/use-view.ts
+++ b/src/use-view.ts
@@ -41,9 +41,23 @@ const useView: TUseView = (config = {}) => {
         generate: (_: any, child: t.JSXElement) => child,
         imports: {},
       };
-  const onUpdate = config.onUpdate ? config.onUpdate : () => {};
+
+  const onUpdate = ({code}: {code: string}) => {
+    history.replaceState(
+      null,
+      '',
+      `${window.location.search.split('&code')[0]}&code=${encodeURI(code)}`
+    );
+    config.onUpdate && config.onUpdate({code});
+  };
+
+  const urlParams = new URLSearchParams(window.location.search);
+  const urlInitialCode = urlParams.get('code');
+
   const customProps = config.customProps ? config.customProps : {};
-  const initialCode = config.initialCode;
+  const initialCode = urlInitialCode
+    ? decodeURI(urlInitialCode)
+    : config.initialCode;
 
   const [hydrated, setHydrated] = useState(false);
   const [error, setError] = useState<TError>({where: '', msg: null});


### PR DESCRIPTION
I'm not entirely satisfied nor confident with this implementation, but it works. The only caveat being that the URL wont "change" in the address bar, but clicking the copy button does retrieve the correct URL with code.

No worries if this doesn't get merged, just thought I would put this up just in case 🙂

re: #17