### PR TITLE
Vscode snippet

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Learn how to add code owners here:
+# https://help.github.com/en/articles/about-code-owners
+* @gergelyke @chasestarr @nadiia @tajo @sandgraham

--- a/src/code-generator.ts
+++ b/src/code-generator.ts
@@ -186,7 +186,7 @@ export const getAstJsxElement = (
   );
 };
 
-const addToImportList = (
+export const addToImportList = (
   importList: TImportsConfig,
   imports: TImportsConfig
 ) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import lightTheme from './light-theme';
 
 import {getAstJsxElement, formatCode} from './code-generator';
 import {parse} from './ast';
+import vscodeSnippet from './snippets/vscode-snippet';
 
 // hooks, utils
 export {useView, useValueDebounce, assertUnreachable};
@@ -32,6 +33,9 @@ export {PropTypes, lightTheme};
 
 // ast helpers
 export {getAstJsxElement, formatCode, parse};
+
+// vscode snippet generator
+export {vscodeSnippet};
 
 // types
 export * from './types';

--- a/src/snippets/__tests__/vscode-snippet.test.ts
+++ b/src/snippets/__tests__/vscode-snippet.test.ts
@@ -330,4 +330,29 @@ describe('vscodeSnippet component', () => {
       },
     });
   });
+  test('prop formatting (prettier)', () => {
+    expect(
+      vscodeSnippet({
+        componentName: 'Button',
+        props: {
+          enhancer: {
+            value: '() => { return   <div>Blah</div>}',
+            type: PropTypes.Function,
+            description: 'Foo',
+          },
+        },
+      })
+    ).toEqual({
+      Button: {
+        body: [
+          '<Button',
+          '  ${1:enhancer={${2:() => {\n  return <div>Blah</div>;\n}}\\}}',
+          '/>',
+        ],
+        description: 'Base Button component.',
+        prefix: ['Button component'],
+        scope: 'javascript,javascriptreact,typescript,typescriptreact',
+      },
+    });
+  });
 });

--- a/src/snippets/__tests__/vscode-snippet.test.ts
+++ b/src/snippets/__tests__/vscode-snippet.test.ts
@@ -346,7 +346,7 @@ describe('vscodeSnippet component', () => {
       Button: {
         body: [
           '<Button',
-          '  ${1:enhancer={${2:() => {\n    return <div>Blah</div>;\n  }}\\}}',
+          '  ${1:enhancer={${2:() => {\n    return <div>Blah</div>;\n  \\}}\\}}',
           '/>',
         ],
         description: 'Base Button component.',
@@ -355,7 +355,7 @@ describe('vscodeSnippet component', () => {
       },
     });
   });
-  test('prop formatting child (prettier)', () => {
+  test('prop formatting child function (prettier)', () => {
     expect(
       vscodeSnippet({
         componentName: 'Button',
@@ -372,7 +372,33 @@ describe('vscodeSnippet component', () => {
         body: [
           '<Button',
           '>',
-          '  ${1:() => {\n    return <div>Blah</div>;\n  }}',
+          '  ${1:() => {\n    return <div>Blah</div>;\n  \\}}',
+          '</Button>',
+        ],
+        description: 'Base Button component.',
+        prefix: ['Button component'],
+        scope: 'javascript,javascriptreact,typescript,typescriptreact',
+      },
+    });
+  });
+  test('prop formatting child components (prettier)', () => {
+    expect(
+      vscodeSnippet({
+        componentName: 'Button',
+        props: {
+          children: {
+            value: `<span>Foo</span><span>Baz</span><span>Ok</span>`,
+            type: PropTypes.Function,
+            description: 'Foo',
+          },
+        },
+      })
+    ).toEqual({
+      Button: {
+        body: [
+          '<Button',
+          '>',
+          '  ${1:<span>Foo</span>\n  <span>Baz</span>\n  <span>Ok</span>}',
           '</Button>',
         ],
         description: 'Base Button component.',

--- a/src/snippets/__tests__/vscode-snippet.test.ts
+++ b/src/snippets/__tests__/vscode-snippet.test.ts
@@ -1,0 +1,333 @@
+/*
+Copyright (c) 2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+import {vscodeSnippet, PropTypes} from '../../index';
+
+describe('vscodeSnippet imports', () => {
+  test('no imports', () => {
+    expect(
+      vscodeSnippet({
+        componentName: 'Button',
+      })['Button import']
+    ).toBeUndefined();
+  });
+  test('single default import', () => {
+    expect(
+      vscodeSnippet({
+        componentName: 'Button',
+        imports: {
+          'your-button-component': {
+            default: 'Button',
+          },
+        },
+      })['Button import']
+    ).toEqual({
+      body: ["import ${1:Button} from 'your-button-component';"],
+      description: 'Base Button import.',
+      prefix: ['Button import'],
+      scope: 'javascript,javascriptreact,typescript,typescriptreact',
+    });
+  });
+  test('single named import', () => {
+    expect(
+      vscodeSnippet({
+        componentName: 'Button',
+        imports: {
+          'your-button-component': {
+            named: ['SIZE'],
+          },
+        },
+      })['Button import']
+    ).toEqual({
+      body: ["import ${1:{${2:SIZE}\\}} from 'your-button-component';"],
+      description: 'Base Button import.',
+      prefix: ['Button import'],
+      scope: 'javascript,javascriptreact,typescript,typescriptreact',
+    });
+  });
+  test('multiple named imports', () => {
+    expect(
+      vscodeSnippet({
+        componentName: 'Button',
+        imports: {
+          'your-button-component': {
+            named: ['SIZE', 'KIND'],
+          },
+        },
+      })['Button import']
+    ).toEqual({
+      body: [
+        "import ${1:{${2:SIZE, }${3:KIND}\\}} from 'your-button-component';",
+      ],
+      description: 'Base Button import.',
+      prefix: ['Button import'],
+      scope: 'javascript,javascriptreact,typescript,typescriptreact',
+    });
+  });
+  test('default import and named imports', () => {
+    expect(
+      vscodeSnippet({
+        componentName: 'Button',
+        imports: {
+          'your-button-component': {
+            named: ['SIZE', 'KIND'],
+            default: 'Button',
+          },
+        },
+      })['Button import']
+    ).toEqual({
+      body: [
+        "import ${1:Button, }${2:{${3:SIZE, }${4:KIND}\\}} from 'your-button-component';",
+      ],
+      description: 'Base Button import.',
+      prefix: ['Button import'],
+      scope: 'javascript,javascriptreact,typescript,typescriptreact',
+    });
+  });
+  test('multiple from sources', () => {
+    expect(
+      vscodeSnippet({
+        componentName: 'Button',
+        imports: {
+          'your-button-component': {
+            named: ['SIZE', 'KIND'],
+            default: 'Button',
+          },
+          'your-toast-component': {
+            default: 'Toast',
+          },
+        },
+      })['Button import']
+    ).toEqual({
+      body: [
+        "import ${1:Button, }${2:{${3:SIZE, }${4:KIND}\\}} from 'your-button-component';",
+        "import ${5:Toast} from 'your-toast-component';",
+      ],
+      description: 'Base Button import.',
+      prefix: ['Button import'],
+      scope: 'javascript,javascriptreact,typescript,typescriptreact',
+    });
+  });
+  test('prop imports', () => {
+    expect(
+      vscodeSnippet({
+        componentName: 'Button',
+        props: {
+          size: {
+            value: false,
+            type: PropTypes.Boolean,
+            description: '',
+            imports: {
+              'your-button-component': {
+                named: ['SIZE'],
+              },
+            },
+          },
+          kind: {
+            value: false,
+            type: PropTypes.Boolean,
+            description: '',
+            imports: {
+              'your-button-component': {
+                named: ['KIND'],
+              },
+            },
+          },
+        },
+      })['Button import']
+    ).toEqual({
+      body: [
+        "import ${1:{${2:SIZE, }${3:KIND}\\}} from 'your-button-component';",
+      ],
+      description: 'Base Button import.',
+      prefix: ['Button import'],
+      scope: 'javascript,javascriptreact,typescript,typescriptreact',
+    });
+  });
+});
+describe('vscodeSnippet component', () => {
+  test('no props', () => {
+    expect(
+      vscodeSnippet({
+        componentName: 'Button',
+      })
+    ).toEqual({
+      Button: {
+        body: ['<Button', '/>'],
+        description: 'Base Button component.',
+        prefix: ['Button'],
+        scope: 'javascript,javascriptreact,typescript,typescriptreact',
+      },
+    });
+  });
+  test('generic prop', () => {
+    expect(
+      vscodeSnippet({
+        componentName: 'Button',
+        props: {
+          onClick: {
+            value: '() => alert("click")',
+            type: PropTypes.Function,
+            description: `Function called when button is clicked.`,
+          },
+        },
+      })
+    ).toEqual({
+      Button: {
+        body: ['<Button', '  ${1:onClick={${2:() => alert("click")}\\}}', '/>'],
+        description: 'Base Button component.',
+        prefix: ['Button'],
+        scope: 'javascript,javascriptreact,typescript,typescriptreact',
+      },
+    });
+  });
+  test('boolean prop', () => {
+    expect(
+      vscodeSnippet({
+        componentName: 'Button',
+        props: {
+          disabled: {
+            value: false,
+            type: PropTypes.Boolean,
+            description: 'Indicates that the button is disabled',
+          },
+        },
+      })
+    ).toEqual({
+      Button: {
+        body: ['<Button', '  ${1:disabled}', '/>'],
+        description: 'Base Button component.',
+        prefix: ['Button'],
+        scope: 'javascript,javascriptreact,typescript,typescriptreact',
+      },
+    });
+  });
+  test('enum prop', () => {
+    expect(
+      vscodeSnippet({
+        componentName: 'Button',
+        props: {
+          size: {
+            value: 'SIZE.default',
+            defaultValue: 'SIZE.default',
+            options: {default: 'default', big: 'big'},
+            type: PropTypes.Enum,
+            description: 'Defines the size of the button.',
+            imports: {},
+          },
+        },
+      })
+    ).toEqual({
+      Button: {
+        body: ['<Button', '  ${1:size={${2|SIZE.default,SIZE.big|}\\}}', '/>'],
+        description: 'Base Button component.',
+        prefix: ['Button'],
+        scope: 'javascript,javascriptreact,typescript,typescriptreact',
+      },
+    });
+  });
+  test('enum prop with enumName', () => {
+    expect(
+      vscodeSnippet({
+        componentName: 'Button',
+        props: {
+          size: {
+            value: 'CUSTOM.default',
+            defaultValue: 'CUSTOM.default',
+            enumName: 'CUSTOM',
+            options: {big: 'big', default: 'default'},
+            type: PropTypes.Enum,
+            description: 'Defines the size of the button.',
+            imports: {},
+          },
+        },
+      })
+    ).toEqual({
+      Button: {
+        body: [
+          '<Button',
+          '  ${1:size={${2|CUSTOM.default,CUSTOM.big|}\\}}',
+          '/>',
+        ],
+        description: 'Base Button component.',
+        prefix: ['Button'],
+        scope: 'javascript,javascriptreact,typescript,typescriptreact',
+      },
+    });
+  });
+  test('enum prop without imports', () => {
+    expect(
+      vscodeSnippet({
+        componentName: 'Button',
+        props: {
+          size: {
+            value: 'default',
+            defaultValue: 'default',
+            options: {big: 'big', default: 'default'},
+            type: PropTypes.Enum,
+            description: 'Defines the size of the button.',
+          },
+        },
+      })
+    ).toEqual({
+      Button: {
+        body: ['<Button', '  ${1:size={${2|default,big|}\\}}', '/>'],
+        description: 'Base Button component.',
+        prefix: ['Button'],
+        scope: 'javascript,javascriptreact,typescript,typescriptreact',
+      },
+    });
+  });
+  test('enum prop with values containing a dash', () => {
+    expect(
+      vscodeSnippet({
+        componentName: 'Button',
+        props: {
+          size: {
+            value: "SIZE['default-val']",
+            defaultValue: "SIZE['default-val']",
+            options: {['default-val']: 'default-val', ['big-val']: 'big-val'},
+            type: PropTypes.Enum,
+            description: 'Defines the size of the button.',
+            imports: {},
+          },
+        },
+      })
+    ).toEqual({
+      Button: {
+        body: [
+          '<Button',
+          "  ${1:size={${2|SIZE['default-val'],SIZE['big-val']|}\\}}",
+          '/>',
+        ],
+        description: 'Base Button component.',
+        prefix: ['Button'],
+        scope: 'javascript,javascriptreact,typescript,typescriptreact',
+      },
+    });
+  });
+  test('children prop', () => {
+    expect(
+      vscodeSnippet({
+        componentName: 'Button',
+        props: {
+          children: {
+            value: 'Hey',
+            type: PropTypes.String,
+            description: 'Foo',
+          },
+        },
+      })
+    ).toEqual({
+      Button: {
+        body: ['<Button', '>', '  ${1:Hey}', '</Button>'],
+        description: 'Base Button component.',
+        prefix: ['Button'],
+        scope: 'javascript,javascriptreact,typescript,typescriptreact',
+      },
+    });
+  });
+});

--- a/src/snippets/__tests__/vscode-snippet.test.ts
+++ b/src/snippets/__tests__/vscode-snippet.test.ts
@@ -346,8 +346,34 @@ describe('vscodeSnippet component', () => {
       Button: {
         body: [
           '<Button',
-          '  ${1:enhancer={${2:() => {\n  return <div>Blah</div>;\n}}\\}}',
+          '  ${1:enhancer={${2:() => {\n    return <div>Blah</div>;\n  }}\\}}',
           '/>',
+        ],
+        description: 'Base Button component.',
+        prefix: ['Button component'],
+        scope: 'javascript,javascriptreact,typescript,typescriptreact',
+      },
+    });
+  });
+  test('prop formatting child (prettier)', () => {
+    expect(
+      vscodeSnippet({
+        componentName: 'Button',
+        props: {
+          children: {
+            value: `() => { return   <div>Blah</div>}`,
+            type: PropTypes.Function,
+            description: 'Foo',
+          },
+        },
+      })
+    ).toEqual({
+      Button: {
+        body: [
+          '<Button',
+          '>',
+          '  ${1:() => {\n    return <div>Blah</div>;\n  }}',
+          '</Button>',
         ],
         description: 'Base Button component.',
         prefix: ['Button component'],

--- a/src/snippets/__tests__/vscode-snippet.test.ts
+++ b/src/snippets/__tests__/vscode-snippet.test.ts
@@ -158,7 +158,7 @@ describe('vscodeSnippet component', () => {
       Button: {
         body: ['<Button', '/>'],
         description: 'Base Button component.',
-        prefix: ['Button'],
+        prefix: ['Button component'],
         scope: 'javascript,javascriptreact,typescript,typescriptreact',
       },
     });
@@ -179,7 +179,7 @@ describe('vscodeSnippet component', () => {
       Button: {
         body: ['<Button', '  ${1:onClick={${2:() => alert("click")}\\}}', '/>'],
         description: 'Base Button component.',
-        prefix: ['Button'],
+        prefix: ['Button component'],
         scope: 'javascript,javascriptreact,typescript,typescriptreact',
       },
     });
@@ -200,7 +200,7 @@ describe('vscodeSnippet component', () => {
       Button: {
         body: ['<Button', '  ${1:disabled}', '/>'],
         description: 'Base Button component.',
-        prefix: ['Button'],
+        prefix: ['Button component'],
         scope: 'javascript,javascriptreact,typescript,typescriptreact',
       },
     });
@@ -224,7 +224,7 @@ describe('vscodeSnippet component', () => {
       Button: {
         body: ['<Button', '  ${1:size={${2|SIZE.default,SIZE.big|}\\}}', '/>'],
         description: 'Base Button component.',
-        prefix: ['Button'],
+        prefix: ['Button component'],
         scope: 'javascript,javascriptreact,typescript,typescriptreact',
       },
     });
@@ -253,7 +253,7 @@ describe('vscodeSnippet component', () => {
           '/>',
         ],
         description: 'Base Button component.',
-        prefix: ['Button'],
+        prefix: ['Button component'],
         scope: 'javascript,javascriptreact,typescript,typescriptreact',
       },
     });
@@ -276,7 +276,7 @@ describe('vscodeSnippet component', () => {
       Button: {
         body: ['<Button', '  ${1:size={${2|default,big|}\\}}', '/>'],
         description: 'Base Button component.',
-        prefix: ['Button'],
+        prefix: ['Button component'],
         scope: 'javascript,javascriptreact,typescript,typescriptreact',
       },
     });
@@ -304,7 +304,7 @@ describe('vscodeSnippet component', () => {
           '/>',
         ],
         description: 'Base Button component.',
-        prefix: ['Button'],
+        prefix: ['Button component'],
         scope: 'javascript,javascriptreact,typescript,typescriptreact',
       },
     });
@@ -325,7 +325,7 @@ describe('vscodeSnippet component', () => {
       Button: {
         body: ['<Button', '>', '  ${1:Hey}', '</Button>'],
         description: 'Base Button component.',
-        prefix: ['Button'],
+        prefix: ['Button component'],
         scope: 'javascript,javascriptreact,typescript,typescriptreact',
       },
     });

--- a/src/snippets/vscode-snippet.ts
+++ b/src/snippets/vscode-snippet.ts
@@ -143,7 +143,7 @@ const vscodeSnippet: TVscodeSnippet = ({
 
   output[`${componentName}`] = {
     scope: 'javascript,javascriptreact,typescript,typescriptreact',
-    prefix: [`${prefix || componentName}`],
+    prefix: [`${prefix || componentName} component`],
     description: `Base ${componentName} component.`,
     body: getComponentBody(componentName, props),
   };

--- a/src/snippets/vscode-snippet.ts
+++ b/src/snippets/vscode-snippet.ts
@@ -17,11 +17,26 @@ import {addToImportList} from '../code-generator';
 
 const formatCode = (code: TPropValue) => {
   if (code && typeof code === 'string') {
+    const isJsx = code.startsWith('<');
     try {
-      code = rvFormatCode(code);
-      return code.replace(/\n/g, '\n  ');
+      if (isJsx) {
+        code = rvFormatCode(`<>${code}</>`);
+      } else {
+        code = rvFormatCode(`<>{${code}}</>`);
+      }
+      const addSpaces = !code.startsWith('<>\n');
+      if (isJsx) {
+        code = code.replace(/^<>\s*/, '').replace(/\s*<\/>$/, '');
+      } else {
+        code = code.replace(/^<>\s*\{/, '').replace(/\}\s*<\/>$/, '');
+      }
+      if (addSpaces) {
+        code = code.replace(/\n/g, '\n  ');
+      }
     } catch (e) {}
+    code = code.replace(/\}/g, '\\}').replace(/\$\{/g, '$\\{');
   }
+
   return code;
 };
 

--- a/src/snippets/vscode-snippet.ts
+++ b/src/snippets/vscode-snippet.ts
@@ -1,0 +1,148 @@
+/*
+Copyright (c) 2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+import {clone} from '../utils';
+import {TProp, TImportsConfig, PropTypes} from '../';
+import {addToImportList} from '../code-generator';
+
+const joinNamed = (items: string[] | undefined, ctr: number) => {
+  if (!items) return '';
+  let output = `\${${ctr++}:{`;
+  for (let i = 0; i < items.length; i++) {
+    if (i !== items.length - 1) {
+      output += `\${${ctr++}:${items[i]}, }`;
+    } else {
+      output += `\${${ctr++}:${items[i]}}`;
+    }
+  }
+  return `${output}\\}}`;
+};
+
+type TVscodeSnippetOutput = {
+  [key: string]: {
+    body: string[];
+    description: string;
+    prefix: string[];
+    scope: string;
+  };
+};
+
+type TVscodeSnippet = (props: {
+  componentName: string;
+  imports?: TImportsConfig;
+  props?: {[key: string]: TProp<any>};
+}) => TVscodeSnippetOutput;
+
+const getImportBody = (
+  imports?: TImportsConfig,
+  props?: {[key: string]: TProp<any>}
+) => {
+  const importList: TImportsConfig = imports ? clone(imports) : {};
+  // prop level imports (typically enums related) that are displayed
+  // only when the prop is being used
+  props &&
+    Object.values(props).forEach(prop => {
+      if (prop.imports) {
+        addToImportList(importList, prop.imports);
+      }
+    });
+  const importBody: string[] = [];
+  let ctr = 1;
+  for (const from in importList) {
+    const def = importList[from].default;
+    const named =
+      Array.isArray(importList[from].named) &&
+      (importList[from].named as string[]).length > 0
+        ? importList[from].named
+        : undefined;
+    const defaultImport = def ? `\${${ctr++}:${def}${named ? ', }' : '}'}` : '';
+    importBody.push(
+      `import ${defaultImport}${joinNamed(named, ctr)} from '${from}';`
+    );
+    if (named) {
+      ctr += named.length + 1;
+    }
+  }
+  return importBody;
+};
+
+const getComponentBody = (
+  componentName: string,
+  props?: {[key: string]: TProp<any>}
+) => {
+  let ctr2 = 1;
+  const componentBody = [`<${componentName}`];
+  if (props) {
+    for (const propName in props) {
+      if (props[propName].hidden) continue;
+      if (propName === 'children' || propName === 'overrides') continue;
+      if (props[propName].type === PropTypes.Boolean) {
+        const row = `  \${${ctr2++}:${propName}}`;
+        componentBody.push(row);
+      } else if (props[propName].type === PropTypes.Enum) {
+        const enumName = props[propName].imports
+          ? props[propName].enumName || propName.toUpperCase()
+          : null;
+        const opts = Object.values(props[propName].options)
+          .map((opt: any) =>
+            enumName
+              ? opt.includes('-')
+                ? `${enumName}['${opt}']`
+                : `${enumName}.${opt}`
+              : opt
+          )
+          .filter(opt => opt !== props[propName].defaultValue);
+        if (props[propName].defaultValue) {
+          opts.unshift(props[propName].defaultValue as string);
+        }
+        const row = `  \${${ctr2++}:${propName}={\${${ctr2++}|${opts.join(
+          ','
+        )}|}\\}}`;
+        componentBody.push(row);
+      } else {
+        const row = `  \${${ctr2++}:${propName}={\${${ctr2++}:${props[propName]
+          .defaultValue || props[propName].value}}\\}}`;
+        componentBody.push(row);
+      }
+    }
+    if (props['children'] && !props['children'].hidden) {
+      componentBody.push('>');
+      componentBody.push(`  \${${ctr2++}:${props['children'].value}}`);
+      componentBody.push(`</${componentName}>`);
+    } else {
+      componentBody.push(`/>`);
+    }
+  } else {
+    componentBody.push(`/>`);
+  }
+  return componentBody;
+};
+
+const vscodeSnippet: TVscodeSnippet = ({componentName, imports, props}) => {
+  const output: TVscodeSnippetOutput = {};
+
+  const importBody = getImportBody(imports, props);
+  if (importBody.length > 0) {
+    output[`${componentName} import`] = {
+      scope: 'javascript,javascriptreact,typescript,typescriptreact',
+      prefix: [`${componentName} import`],
+      description: `Base ${componentName} import.`,
+      body: importBody,
+    };
+  }
+
+  output[`${componentName}`] = {
+    scope: 'javascript,javascriptreact,typescript,typescriptreact',
+    prefix: [`${componentName}`],
+    description: `Base ${componentName} component.`,
+    body: getComponentBody(componentName, props),
+  };
+
+  return output;
+};
+
+export default vscodeSnippet;

--- a/src/snippets/vscode-snippet.ts
+++ b/src/snippets/vscode-snippet.ts
@@ -79,7 +79,7 @@ const getComponentBody = (
   if (props) {
     for (const propName in props) {
       if (props[propName].hidden) continue;
-      if (propName === 'children' || propName === 'overrides') continue;
+      if (propName === 'children') continue;
       if (props[propName].type === PropTypes.Boolean) {
         const row = `  \${${ctr2++}:${propName}}`;
         componentBody.push(row);

--- a/src/snippets/vscode-snippet.ts
+++ b/src/snippets/vscode-snippet.ts
@@ -17,7 +17,10 @@ import {addToImportList} from '../code-generator';
 
 const formatCode = (code: TPropValue) => {
   if (code && typeof code === 'string') {
-    return rvFormatCode(code);
+    try {
+      code = rvFormatCode(code);
+      return code.replace(/\n/g, '\n  ');
+    } catch (e) {}
   }
   return code;
 };
@@ -126,7 +129,9 @@ const getComponentBody = (
     }
     if (props['children'] && !props['children'].hidden) {
       componentBody.push('>');
-      componentBody.push(`  \${${ctr++}:${props['children'].value}}`);
+      componentBody.push(
+        `  \${${ctr++}:${formatCode(props['children'].value)}}`
+      );
       componentBody.push(`</${componentName}>`);
     } else {
       componentBody.push(`/>`);

--- a/src/snippets/vscode-snippet.ts
+++ b/src/snippets/vscode-snippet.ts
@@ -33,6 +33,7 @@ type TVscodeSnippetOutput = {
 
 type TVscodeSnippet = (props: {
   componentName: string;
+  prefix?: string;
   imports?: TImportsConfig;
   props?: {[key: string]: TProp<any>};
 }) => TVscodeSnippetOutput;
@@ -122,14 +123,19 @@ const getComponentBody = (
   return componentBody;
 };
 
-const vscodeSnippet: TVscodeSnippet = ({componentName, imports, props}) => {
+const vscodeSnippet: TVscodeSnippet = ({
+  componentName,
+  prefix,
+  imports,
+  props,
+}) => {
   const output: TVscodeSnippetOutput = {};
 
   const importBody = getImportBody(imports, props);
   if (importBody.length > 0) {
     output[`${componentName} import`] = {
       scope: 'javascript,javascriptreact,typescript,typescriptreact',
-      prefix: [`${componentName} import`],
+      prefix: [`${prefix || componentName} import`],
       description: `Base ${componentName} import.`,
       body: importBody,
     };
@@ -137,7 +143,7 @@ const vscodeSnippet: TVscodeSnippet = ({componentName, imports, props}) => {
 
   output[`${componentName}`] = {
     scope: 'javascript,javascriptreact,typescript,typescriptreact',
-    prefix: [`${componentName}`],
+    prefix: [`${prefix || componentName}`],
     description: `Base ${componentName} component.`,
     body: getComponentBody(componentName, props),
   };

--- a/src/snippets/vscode-snippet.ts
+++ b/src/snippets/vscode-snippet.ts
@@ -6,8 +6,21 @@ LICENSE file in the root directory of this source tree.
 */
 
 import {clone} from '../utils';
-import {TProp, TImportsConfig, PropTypes} from '../';
+import {
+  TProp,
+  TPropValue,
+  TImportsConfig,
+  PropTypes,
+  formatCode as rvFormatCode,
+} from '../';
 import {addToImportList} from '../code-generator';
+
+const formatCode = (code: TPropValue) => {
+  if (code && typeof code === 'string') {
+    return rvFormatCode(code);
+  }
+  return code;
+};
 
 const joinNamed = (items: string[] | undefined, ctr: number) => {
   if (!items) return '';
@@ -105,8 +118,9 @@ const getComponentBody = (
         )}|}\\}}`;
         componentBody.push(row);
       } else {
-        const row = `  \${${ctr++}:${propName}={\${${ctr++}:${props[propName]
-          .defaultValue || props[propName].value}}\\}}`;
+        const row = `  \${${ctr++}:${propName}={\${${ctr++}:${formatCode(
+          props[propName].defaultValue || props[propName].value
+        )}}\\}}`;
         componentBody.push(row);
       }
     }

--- a/src/snippets/vscode-snippet.ts
+++ b/src/snippets/vscode-snippet.ts
@@ -74,14 +74,14 @@ const getComponentBody = (
   componentName: string,
   props?: {[key: string]: TProp<any>}
 ) => {
-  let ctr2 = 1;
+  let ctr = 1;
   const componentBody = [`<${componentName}`];
   if (props) {
     for (const propName in props) {
       if (props[propName].hidden) continue;
       if (propName === 'children') continue;
       if (props[propName].type === PropTypes.Boolean) {
-        const row = `  \${${ctr2++}:${propName}}`;
+        const row = `  \${${ctr++}:${propName}}`;
         componentBody.push(row);
       } else if (props[propName].type === PropTypes.Enum) {
         const enumName = props[propName].imports
@@ -99,19 +99,19 @@ const getComponentBody = (
         if (props[propName].defaultValue) {
           opts.unshift(props[propName].defaultValue as string);
         }
-        const row = `  \${${ctr2++}:${propName}={\${${ctr2++}|${opts.join(
+        const row = `  \${${ctr++}:${propName}={\${${ctr++}|${opts.join(
           ','
         )}|}\\}}`;
         componentBody.push(row);
       } else {
-        const row = `  \${${ctr2++}:${propName}={\${${ctr2++}:${props[propName]
+        const row = `  \${${ctr++}:${propName}={\${${ctr++}:${props[propName]
           .defaultValue || props[propName].value}}\\}}`;
         componentBody.push(row);
       }
     }
     if (props['children'] && !props['children'].hidden) {
       componentBody.push('>');
-      componentBody.push(`  \${${ctr2++}:${props['children'].value}}`);
+      componentBody.push(`  \${${ctr++}:${props['children'].value}}`);
       componentBody.push(`</${componentName}>`);
     } else {
       componentBody.push(`/>`);


### PR DESCRIPTION
This adds a new export - `vscodeSnippet` function. It takes three arguments

- `componentName`
- `props` - same format as react-view config
- `imports` - same format as react-view config

...and outputs VS Code snippets for imports and the component. It's up to the user to actually stringify the output `vscodeSnippet` and generate `.code-snippets` files. In our case, we will have some script in Base Web that will load our component config files, generates the snippets and publish them as a part of our VS Code extension.

For now, not adding any documentation. Let's test it with Base Web first. Also, it might be a good topic for standalone article.