### PR TITLE
Force re-compilation for a specific edge-case

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -15,6 +15,7 @@ const loaderFn = () => [
   require('../examples/use-view.stories.tsx'),
   require('../examples/view.stories.tsx'),
   require('../examples/advanced.stories.tsx'),
+  require('../examples/test.stories.tsx'),
 ];
 
 configure(loaderFn, module);

--- a/examples/__tests__/modal.test.ts
+++ b/examples/__tests__/modal.test.ts
@@ -1,0 +1,27 @@
+/*
+Copyright (c) 2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+import {urls} from '../const';
+
+jest.setTimeout(20 * 1000);
+
+describe.only('Modal', () => {
+  beforeAll(async () => {
+    await page.goto(urls.modal);
+  });
+
+  it('open, close and open the modal', async () => {
+    await (await page.$('#show'))?.click();
+    await page.waitFor(300); // waiting for debounce
+    expect((await page.$('#close-modal')) !== null).toBeTruthy();
+    (await page.$('#close-modal'))?.click();
+    await page.waitFor(500); // waiting for debounce
+    expect((await page.$('#close-modal')) !== null).toBeFalsy();
+    await (await page.$('#show'))?.click();
+    await page.waitFor(300); // waiting for debounce
+    expect((await page.$('#close-modal')) !== null).toBeTruthy();
+  });
+});

--- a/examples/const.ts
+++ b/examples/const.ts
@@ -12,4 +12,5 @@ export const urls = {
   view: 'http://localhost:6006/iframe.html?id=view--view',
   customProps: 'http://localhost:6006/iframe.html?id=advanced--custom-prop',
   theming: 'http://localhost:6006/iframe.html?id=advanced--theming',
+  modal: 'http://localhost:6006/iframe.html?id=tests--modal',
 };

--- a/examples/modal.tsx
+++ b/examples/modal.tsx
@@ -6,38 +6,46 @@ LICENSE file in the root directory of this source tree.
 */
 
 import * as React from 'react';
-//import {View, PropTypes} from '../src/index';
-import {Layout, H1, P} from './layout/';
+import {View, PropTypes} from '../src/index';
+import {Layout, H1} from './layout/';
 import Modal from './showcase-components/modal';
 
-export default () => (
-  <View
-    componentName="asdasd"
-    props={{
-      children: {
-        value: 'Hello',
-        type: PropTypes.ReactNode,
-        description: 'Content of the modal',
-      },
-      handleClose: {
-        value: '() => alert("click")',
-        type: PropTypes.Function,
-        description: 'Function called when button is clicked.',
-      },
-      disabled: {
-        value: false,
-        type: PropTypes.Boolean,
-        description: 'Indicates that the button is disabled',
-      },
-    }}
-    scope={{
-      Button,
-      SIZE,
-    }}
-    imports={{
-      'your-button-component': {
-        named: ['Button'],
-      },
-    }}
-  />
+const ModalExample = () => (
+  <Layout>
+    <H1>Modal example</H1>
+    <View
+      componentName="Modal"
+      props={{
+        show: {
+          value: false,
+          type: PropTypes.Boolean,
+          description: 'Indicates that the modal is visible',
+          stateful: true,
+        },
+        children: {
+          value: 'This is a simple Modal',
+          type: PropTypes.ReactNode,
+          description: 'Content of the modal',
+        },
+        handleClose: {
+          value: '() => setShow(false)',
+          type: PropTypes.Function,
+          description: 'Function called when button is clicked.',
+          propHook: {
+            what: 'false',
+            into: 'show',
+          },
+        },
+      }}
+      scope={{
+        Modal,
+      }}
+      imports={{
+        'your-modal-component': {
+          default: 'Modal',
+        },
+      }}
+    />
+  </Layout>
 );
+export default ModalExample;

--- a/examples/modal.tsx
+++ b/examples/modal.tsx
@@ -7,21 +7,19 @@ LICENSE file in the root directory of this source tree.
 
 import * as React from 'react';
 import {View, PropTypes} from '../src/index';
-import {Layout, H1} from './layout/';
+import {Layout, H1, P} from './layout/';
 import Modal from './showcase-components/modal';
 
 const ModalExample = () => (
   <Layout>
     <H1>Modal example</H1>
+    <P>
+      This is story was created for an e2e test. Reproduces this{' '}
+      <a href="https://github.com/uber/react-view/issues/19">bug report.</a>
+    </P>
     <View
       componentName="Modal"
       props={{
-        show: {
-          value: false,
-          type: PropTypes.Boolean,
-          description: 'Indicates that the modal is visible',
-          stateful: true,
-        },
         children: {
           value: 'This is a simple Modal',
           type: PropTypes.ReactNode,
@@ -35,6 +33,12 @@ const ModalExample = () => (
             what: 'false',
             into: 'show',
           },
+        },
+        show: {
+          value: false,
+          type: PropTypes.Boolean,
+          description: 'Indicates that the modal is visible',
+          stateful: true,
         },
       }}
       scope={{

--- a/examples/modal.tsx
+++ b/examples/modal.tsx
@@ -1,0 +1,43 @@
+/*
+Copyright (c) 2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+import * as React from 'react';
+//import {View, PropTypes} from '../src/index';
+import {Layout, H1, P} from './layout/';
+import Modal from './showcase-components/modal';
+
+export default () => (
+  <View
+    componentName="asdasd"
+    props={{
+      children: {
+        value: 'Hello',
+        type: PropTypes.ReactNode,
+        description: 'Content of the modal',
+      },
+      handleClose: {
+        value: '() => alert("click")',
+        type: PropTypes.Function,
+        description: 'Function called when button is clicked.',
+      },
+      disabled: {
+        value: false,
+        type: PropTypes.Boolean,
+        description: 'Indicates that the button is disabled',
+      },
+    }}
+    scope={{
+      Button,
+      SIZE,
+    }}
+    imports={{
+      'your-button-component': {
+        named: ['Button'],
+      },
+    }}
+  />
+);

--- a/examples/showcase-components/modal.tsx
+++ b/examples/showcase-components/modal.tsx
@@ -12,6 +12,7 @@ const Modal: React.FC<{
   show: boolean;
   children: React.ReactNode;
 }> = ({handleClose, show, children}) => {
+  if (!show) return null;
   return (
     <div
       style={{
@@ -22,7 +23,6 @@ const Modal: React.FC<{
         height: '100%',
         zIndex: 2,
         background: 'rgba(0, 0, 0, 0.6)',
-        display: show ? 'block' : 'none',
       }}
     >
       <section
@@ -43,7 +43,9 @@ const Modal: React.FC<{
         }}
       >
         <p>{children}</p>
-        <button onClick={handleClose}>close modal</button>
+        <button id="close-modal" onClick={handleClose}>
+          close modal
+        </button>
       </section>
     </div>
   );

--- a/examples/showcase-components/modal.tsx
+++ b/examples/showcase-components/modal.tsx
@@ -1,0 +1,45 @@
+/*
+Copyright (c) 2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+import * as React from 'react';
+
+const Modal: React.FC<{
+  handleClose: () => void;
+  show: boolean;
+  children: React.ReactNode;
+}> = ({handleClose, show, children}) => {
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: '0',
+        left: '0',
+        width: '100%',
+        height: '100%',
+        background: 'rgba(0, 0, 0, 0.6)',
+        display: show ? 'block' : 'none',
+      }}
+    >
+      <section
+        style={{
+          position: 'fixed',
+          background: 'white',
+          width: '80%',
+          height: 'auto',
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%,-50%)',
+        }}
+      >
+        {children}
+        <button onClick={handleClose}>close</button>
+      </section>
+    </div>
+  );
+};
+
+export default Modal;

--- a/examples/showcase-components/modal.tsx
+++ b/examples/showcase-components/modal.tsx
@@ -20,23 +20,30 @@ const Modal: React.FC<{
         left: '0',
         width: '100%',
         height: '100%',
+        zIndex: 2,
         background: 'rgba(0, 0, 0, 0.6)',
         display: show ? 'block' : 'none',
       }}
     >
       <section
         style={{
+          fontFamily: "'Helvetica Neue', Arial",
           position: 'fixed',
           background: 'white',
           width: '80%',
           height: 'auto',
+          minHeight: '200px',
+          flexDirection: 'column',
           top: '50%',
           left: '50%',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
           transform: 'translate(-50%,-50%)',
         }}
       >
-        {children}
-        <button onClick={handleClose}>close</button>
+        <p>{children}</p>
+        <button onClick={handleClose}>close modal</button>
       </section>
     </div>
   );

--- a/examples/test.stories.tsx
+++ b/examples/test.stories.tsx
@@ -4,12 +4,13 @@ Copyright (c) 2019 Uber Technologies, Inc.
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
-module.exports = {
-  launch: {
-    headless: process.env.HEADLESS !== 'false',
-    defaultViewport: {
-      width: 763,
-      height: 1000,
-    },
-  },
+import * as React from 'react';
+import Modal from './modal';
+
+export default {
+  title: 'Tests',
+};
+
+export const modal = () => {
+  return <Modal />;
 };

--- a/examples/view.stories.tsx
+++ b/examples/view.stories.tsx
@@ -5,6 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 import * as React from 'react';
+import Modal from './modal';
 import View from './view';
 
 export default {
@@ -13,4 +14,8 @@ export default {
 
 export const view = () => {
   return <View />;
+};
+
+export const modal = () => {
+  return <Modal />;
 };

--- a/examples/view.stories.tsx
+++ b/examples/view.stories.tsx
@@ -5,7 +5,6 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 import * as React from 'react';
-import Modal from './modal';
 import View from './view';
 
 export default {
@@ -14,8 +13,4 @@ export default {
 
 export const view = () => {
   return <View />;
-};
-
-export const modal = () => {
-  return <Modal />;
 };


### PR DESCRIPTION
fixes https://github.com/uber/react-view/issues/19

More described in the code but there is this strange edge case when there is a state change caused by the interaction with component followed by using knob. This is not the most elegant fix but it doesn't require any breaking change or adding some additional mechanism into the compiler component.

Might come up with something better in the future. Added e2e test as well.