### PR TITLE
Fix VS Code snippet string props parsing

### DIFF
--- a/src/snippets/__tests__/vscode-snippet.test.ts
+++ b/src/snippets/__tests__/vscode-snippet.test.ts
@@ -451,4 +451,55 @@ describe('vscodeSnippet component', () => {
       scope: 'javascript,javascriptreact,typescript,typescriptreact',
     });
   });
+  test('treat PropTypes.String props as strings', () => {
+    const props = {
+      placeholder: {
+        value: 'Placeholder',
+        type: PropTypes.String,
+        description: 'Placeholder',
+      },
+    };
+
+    expect(
+      vscodeSnippet({
+        props,
+        componentName: 'Input',
+      })['Input']
+    ).toEqual({
+      body: [
+        '<Input',
+        '  ${1:placeholder="${2:Placeholder}"}',
+        '/>',
+      ],
+      description: 'Base Input component.',
+      prefix: ['Input component'],
+      scope: 'javascript,javascriptreact,typescript,typescriptreact',
+    });
+  });
+  test('ignore undefined values on PropTypes.String props', () => {
+    const props = {
+      value: {
+        value: undefined,
+        type: PropTypes.String,
+        description: 'Value',
+      },
+    };
+
+    expect(
+      vscodeSnippet({
+        props,
+        componentName: 'Input',
+      })['Input']
+    ).toEqual({
+      body: [
+        '<Input',
+        //"  ${8:placeholder=\"${9:Placeholder}\"}",
+        '  ${1:value={${2:undefined}\\}}',
+        '/>',
+      ],
+      description: 'Base Input component.',
+      prefix: ['Input component'],
+      scope: 'javascript,javascriptreact,typescript,typescriptreact',
+    });
+  });
 });

--- a/src/snippets/__tests__/vscode-snippet.test.ts
+++ b/src/snippets/__tests__/vscode-snippet.test.ts
@@ -451,18 +451,16 @@ describe('vscodeSnippet component', () => {
       scope: 'javascript,javascriptreact,typescript,typescriptreact',
     });
   });
-  test('treat PropTypes.String props as strings', () => {
-    const props = {
-      placeholder: {
-        value: 'Placeholder',
-        type: PropTypes.String,
-        description: 'Placeholder',
-      },
-    };
-
+  test('(PropTypes.String prop) append as string literal', () => {
     expect(
       vscodeSnippet({
-        props,
+        props: {
+          placeholder: {
+            value: 'Placeholder',
+            type: PropTypes.String,
+            description: 'Placeholder',
+          },
+        },
         componentName: 'Input',
       })['Input']
     ).toEqual({
@@ -472,18 +470,16 @@ describe('vscodeSnippet component', () => {
       scope: 'javascript,javascriptreact,typescript,typescriptreact',
     });
   });
-  test('ignore undefined values on PropTypes.String props', () => {
-    const props = {
-      value: {
-        value: undefined,
-        type: PropTypes.String,
-        description: 'Value',
-      },
-    };
-
+  test('(PropTypes.String prop) ignore undefined values', () => {
     expect(
       vscodeSnippet({
-        props,
+        props: {
+          value: {
+            value: undefined,
+            type: PropTypes.String,
+            description: 'Value',
+          },
+        },
         componentName: 'Input',
       })['Input']
     ).toEqual({

--- a/src/snippets/__tests__/vscode-snippet.test.ts
+++ b/src/snippets/__tests__/vscode-snippet.test.ts
@@ -466,11 +466,7 @@ describe('vscodeSnippet component', () => {
         componentName: 'Input',
       })['Input']
     ).toEqual({
-      body: [
-        '<Input',
-        '  ${1:placeholder="${2:Placeholder}"}',
-        '/>',
-      ],
+      body: ['<Input', '  ${1:placeholder="${2:Placeholder}"}', '/>'],
       description: 'Base Input component.',
       prefix: ['Input component'],
       scope: 'javascript,javascriptreact,typescript,typescriptreact',
@@ -491,12 +487,7 @@ describe('vscodeSnippet component', () => {
         componentName: 'Input',
       })['Input']
     ).toEqual({
-      body: [
-        '<Input',
-        //"  ${8:placeholder=\"${9:Placeholder}\"}",
-        '  ${1:value={${2:undefined}\\}}',
-        '/>',
-      ],
+      body: ['<Input', '  ${1:value={${2:undefined}\\}}', '/>'],
       description: 'Base Input component.',
       prefix: ['Input component'],
       scope: 'javascript,javascriptreact,typescript,typescriptreact',

--- a/src/snippets/vscode-snippet.ts
+++ b/src/snippets/vscode-snippet.ts
@@ -136,6 +136,14 @@ const getComponentBody = (
           ','
         )}|}\\}}`;
         componentBody.push(row);
+      } else if (
+        props[propName].type === PropTypes.String &&
+        typeof props[propName].value === PropTypes.String
+      ) {
+        const row = `  \${${ctr++}:${propName}="\${${ctr++}:${formatCode(
+          props[propName].defaultValue || props[propName].value
+        )}}\"}`;
+        componentBody.push(row);
       } else {
         const row = `  \${${ctr++}:${propName}={\${${ctr++}:${formatCode(
           props[propName].defaultValue || props[propName].value


### PR DESCRIPTION
re: #26

<hr />

I'm not sure if this is the correct implementation, but I tried to solve the problem of `PropTypes.String` properties being appended as variables in code snippets.

### Example (using the BaseWeb VS Code extension)

![image](https://i.gyazo.com/b26c3a47489f76ab33e5f6783e9e26f3.gif)

### Fixed example

I used the [Input](https://github.com/uber/baseweb/blob/master/documentation-site/components/yard/config/input.ts) config from Base Web to test the changes out. 

(For brevity, I took out some props that required imports, such as `SIZE` etc)

![image](https://i.gyazo.com/3834c28188fa14a102470a531949b5e0.gif)