### PR TITLE
Align generation of value for enum knob across radio buttons and select

### DIFF
--- a/src/ui/knob.tsx
+++ b/src/ui/knob.tsx
@@ -138,6 +138,8 @@ const Knob: React.SFC<{
   imports,
 }) => {
   const [val] = useValueDebounce<TPropValue>(globalVal, globalSet);
+  const getEnumValue = (opt: string) =>
+    imports ? `${enumName || name.toUpperCase()}.${opt}` : opt;
   switch (type) {
     case PropTypes.Ref:
       return (
@@ -178,9 +180,7 @@ const Knob: React.SFC<{
           {numberOfOptions < 7 ? (
             <div style={{display: 'flex', flexWrap: 'wrap'}}>
               {Object.keys(options).map(opt => {
-                const enumValue = imports
-                  ? `${enumName || name.toUpperCase()}.${opt}`
-                  : opt;
+                const enumValue = getEnumValue(opt);
                 return (
                   <div
                     style={{
@@ -224,14 +224,14 @@ const Knob: React.SFC<{
                 borderRadius: '5px',
               }}
             >
-              {Object.keys(options).map(opt => (
-                <option
-                  key={`${name}_${opt}`}
-                  value={`${enumName || name.toUpperCase()}.${opt}`}
-                >
-                  {opt}
-                </option>
-              ))}
+              {Object.keys(options).map(opt => {
+                const enumValue = getEnumValue(opt);
+                return (
+                  <option key={`${name}_${opt}`} value={enumValue}>
+                    {opt}
+                  </option>
+                );
+              })}
             </select>
           )}
 


### PR DESCRIPTION
Thanks for the great library. We are using it in our upcoming design system at [e-conomic](https://github.com/e-conomic), alongside [kind2string](https://www.npmjs.com/package/kind2string) to auto generate react-view examples from typescript types.

I see https://github.com/uber/react-view/pull/16 addressed the ability to support union types without an enum prefix, however the change only affected the radio button knob, and not the select variant shown when there are 7 or more options. This pull request addresses that, and aligns the value across both variants.