### PR TITLE
Fix VSCode snippets enum prop array options extraction

### DIFF
--- a/src/snippets/__tests__/vscode-snippet.test.ts
+++ b/src/snippets/__tests__/vscode-snippet.test.ts
@@ -274,36 +274,11 @@ describe('vscodeSnippet component', () => {
       })
     ).toEqual({
       Button: {
-        body: ['<Button', '  ${1:size={${2|default,big|}\\}}', '/>'],
+        body: ['<Button', '  ${1:size="${2|default,big|}"}', '/>'],
         description: 'Base Button component.',
         prefix: ['Button component'],
         scope: 'javascript,javascriptreact,typescript,typescriptreact',
       },
-    });
-  });
-  test('enum prop without imports (options as array)', () => {
-    expect(
-      vscodeSnippet({
-        props: {
-          variant: {
-            value: 'primary',
-            defaultValue: 'primary',
-            type: PropTypes.Enum,
-            options: ['primary', 'secondary', 'tertiary'],
-            description: 'Variant',
-          },
-        },
-        componentName: 'Button',
-      })['Button']
-    ).toEqual({
-      body: [
-        '<Button',
-        '  ${1:variant="${2|primary,secondary,tertiary|}"}',
-        '/>',
-      ],
-      description: 'Base Button component.',
-      prefix: ['Button component'],
-      scope: 'javascript,javascriptreact,typescript,typescriptreact',
     });
   });
   test('enum prop with values containing a dash', () => {

--- a/src/snippets/__tests__/vscode-snippet.test.ts
+++ b/src/snippets/__tests__/vscode-snippet.test.ts
@@ -281,6 +281,31 @@ describe('vscodeSnippet component', () => {
       },
     });
   });
+  test('enum prop without imports (options as array)', () => {
+    expect(
+      vscodeSnippet({
+        props: {
+          variant: {
+            value: 'primary',
+            defaultValue: 'primary',
+            type: PropTypes.Enum,
+            options: ['primary', 'secondary', 'tertiary'],
+            description: 'Variant',
+          },
+        },
+        componentName: 'Button',
+      })['Button']
+    ).toEqual({
+      body: [
+        '<Button',
+        '  ${1:variant="${2|primary,secondary,tertiary|}"}',
+        '/>',
+      ],
+      description: 'Base Button component.',
+      prefix: ['Button component'],
+      scope: 'javascript,javascriptreact,typescript,typescriptreact',
+    });
+  });
   test('enum prop with values containing a dash', () => {
     expect(
       vscodeSnippet({

--- a/src/snippets/vscode-snippet.ts
+++ b/src/snippets/vscode-snippet.ts
@@ -132,7 +132,7 @@ const getComponentBody = (
         if (props[propName].defaultValue) {
           opts.unshift(props[propName].defaultValue as string);
         }
-        if (Array.isArray(props[propName].options)) {
+        if (!props[propName].imports) {
           const row = `  \${${ctr++}:${propName}="\${${ctr++}|${opts.join(
             ','
           )}|}\"}`;

--- a/src/snippets/vscode-snippet.ts
+++ b/src/snippets/vscode-snippet.ts
@@ -132,10 +132,17 @@ const getComponentBody = (
         if (props[propName].defaultValue) {
           opts.unshift(props[propName].defaultValue as string);
         }
-        const row = `  \${${ctr++}:${propName}={\${${ctr++}|${opts.join(
-          ','
-        )}|}\\}}`;
-        componentBody.push(row);
+        if (Array.isArray(props[propName].options)) {
+          const row = `  \${${ctr++}:${propName}="\${${ctr++}|${opts.join(
+            ','
+          )}|}\"}`;
+          componentBody.push(row);
+        } else {
+          const row = `  \${${ctr++}:${propName}={\${${ctr++}|${opts.join(
+            ','
+          )}|}\\}}`;
+          componentBody.push(row);
+        }
       } else if (
         props[propName].type === PropTypes.String &&
         typeof props[propName].value === PropTypes.String


### PR DESCRIPTION
re: #26 

<hr />

The code is starting to get funky with all these unreadable string concatenations. Maybe it would be possible to add some kind of snapshot-like testing for the JSON output of `vscodeSnippet`? 