### PR TITLE
Zero value is ignored in code generation

### DIFF
--- a/src/__tests__/code-generator.test.ts
+++ b/src/__tests__/code-generator.test.ts
@@ -20,6 +20,32 @@ import {provider} from '../../examples/theming';
 import {customProps} from '../../examples/custom-prop';
 
 describe('getAstPropsArray', () => {
+  test('number (0) and value !== defaulValue', () => {
+    expect(
+      getAstPropsArray(
+        {
+          a: {
+            value: 0,
+            defaultValue: undefined,
+            type: PropTypes.Number,
+            description: '',
+          },
+        },
+        {}
+      )[0]?.value
+    ).toEqual({
+      expression: {
+        extra: {
+          raw: '0',
+          rawValue: 0,
+        },
+        loc: undefined,
+        type: 'NumericLiteral',
+        value: 0,
+      },
+      type: 'JSXExpressionContainer',
+    });
+  });
   test('boolean (true) and value === defaulValue', () => {
     expect(
       getAstPropsArray(

--- a/src/code-generator.ts
+++ b/src/code-generator.ts
@@ -107,7 +107,7 @@ export const getAstPropsArray = (
     // in the view correctly (checked checkboxes and selected default value in radio groups)
     // and not rendered in the component's props.
     if (
-      (typeof value !== 'boolean' && !value) ||
+      (typeof value !== 'boolean' && typeof value !== 'number' && !value) ||
       value === defaultValue ||
       (typeof value === 'boolean' && !value && !defaultValue)
     ) {


### PR DESCRIPTION
We should not ignore zero value when generating code for a property of type Number.

Can be reproduce in  https://codesandbox.io/s/i3dbn?fontsize=14&hidenavigation=1&theme=dark by adding
```
      importantProperty: {
        type:PropTypes.Number,
        value: 0,
        defaultValue: undefined,
        description: 'Do not ignore me!'
      }
```
When changing value from '0' to '1', the code generator works as expected. However, when value is set to '0', code generator ignores 'importantProperty'.

Underlying issue: 
At the moment it is treated as boolean and code-generator return Null for 

```
getAstPropsArray(
        {
          a: {
            value: 0,
            defaultValue: undefined,
            type: PropTypes.Number,
            description: '',
          },
        },
        {}
      )[0]
```