### PR TITLE
Fix write React element expressions in live code editor without rendered anything

### DIFF
--- a/src/ui/compiler.tsx
+++ b/src/ui/compiler.tsx
@@ -41,6 +41,7 @@ const evalCode = (
       presets: presets ? [presetReact, ...presets] : [presetReact],
       inputSourceMap: false as any,
       sourceMaps: false,
+      comments: false,
       // TS preset needs this and it doesn't seem to matter when TS preset
       // is not used, so let's keep it here?
       filename: 'file.tsx',


### PR DESCRIPTION
In my project ( use babel ^7.12 ), if write react element expression in live code editor, like:

```jsx
<button>Hello<button>
```

Nothing is rendered in `Compiler` component.

I checked the code of the Compiler component and found that the problem was in the `evalCode` method:

![image](https://user-images.githubusercontent.com/2755933/108080756-2b1d6f80-70ab-11eb-92ac-4f05ff22bc0c.png)

In my project, after the expression in the above example is transformed by the `transformFromAstSync` method, the returned `transformedCode.code` is:

```js
/*#__PURE__*/
React.createElement("button", null, "hello");
```

So the generated `res` method is:

```js
function anonymous(React, ...otherArguments) {
return /*#__PURE__*/
React.createElement("button", null, "Hello");
}
```

Obviously, this method will always return `undefined`.

This should be a problem with babel, but I don't know how to report it to them.

But in react-view, it should be possible to circumvent this problem by prohibiting the generation of comments.