### PR TITLE
remove className from useView props to reflect behaviour

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -46,8 +46,11 @@ export type TUseViewParams<CustomPropFields = any> = {
   initialCode?: string;
   provider?: TProvider;
   customProps?: TCustomProps;
-  className?: string;
 };
+
+export interface TViewParams extends TUseViewParams {
+  className?: string;
+}
 
 export type TCompilerProps = {
   scope: {[key: string]: any};
@@ -88,10 +91,13 @@ export type TErrorProps = {
 export type TUseView = <ProviderValue = any, CustomPropFields = any>(
   params?: TUseViewParams<CustomPropFields>
 ) => {
-  compilerProps: Omit<TCompilerProps, 'minHeight' | 'placeholder' | 'presets'>;
+  compilerProps: Omit<
+    TCompilerProps,
+    'minHeight' | 'placeholder' | 'presets' | 'className'
+  >;
   knobProps: TKnobsProps;
-  editorProps: TEditorProps;
-  errorProps: TErrorProps;
+  editorProps: Omit<TEditorProps, 'className'>;
+  errorProps: Omit<TErrorProps, 'className'>;
   providerValue: ProviderValue;
   actions: {
     formatCode: () => void;

--- a/src/ui/view.tsx
+++ b/src/ui/view.tsx
@@ -16,9 +16,9 @@ import {
 } from '../index';
 import {getStyles} from '../utils';
 
-import {TUseViewParams} from '../types';
+import {TViewParams} from '../types';
 
-const View: React.FC<TUseViewParams> = (args) => {
+const View: React.FC<TViewParams> = (args) => {
   const params = useView(args);
   return (
     <div {...getStyles({maxWidth: '600px'}, args.className)}>


### PR DESCRIPTION
This is just updating the types to reflect that `className` isn't used by `useView` or exported in its output. 

Should it? That's a different discussion: we'd have to decide which of the three components it applied to or add new props and prefix them in some manner (e.g. `compilerClassName`, `editorClassName`, and `errorClassName`).