### PR TITLE
Upgrade `react-tiny-popover` (Fixes an issue with react and react-dom peer dependencies)

### DIFF
--- a/.changeset/long-flies-hang.md
+++ b/.changeset/long-flies-hang.md
@@ -1,0 +1,5 @@
+---
+"react-view": patch
+---
+
+Updated react-tiny-popover to use React 17 and 18

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,9 @@ pnpm ladle serve
 pnpm typecheck
 pnpm lint
 pnpm test
+
+pnpm exec playwright install
+pnpm test:e2e:dev
 ```
 
 All features and bug fixes should be covered by unit or e2e tests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,19 +5,21 @@
 ```sh
 git clone https://github.com/uber/react-view
 cd react-view
-yarn
+pnpm install
 ```
 
-2. You can test your changes inside of the storybook:
+2. You can test your changes inside of the Ladle dev server by running:
 
 ```sh
-yarn storybook
+pnpm ladle serve
 ```
 
 3. When done, run all unit tests, e2e tests, typescript check and eslint via:
 
 ```sh
-yarn test:ci
+pnpm typecheck
+pnpm lint
+pnpm test
 ```
 
 All features and bug fixes should be covered by unit or e2e tests.

--- a/package.json
+++ b/package.json
@@ -49,11 +49,11 @@
     "@babel/traverse": "^7.23.4",
     "@babel/types": "^7.23.4",
     "@miksu/prettier": "^1.18.6",
-    "@miksu/react-tiny-popover": "^3.5.1",
     "copy-to-clipboard": "^3.3.3",
     "lodash": "^4.17.21",
     "prism-react-renderer": "^2.3.0",
-    "react-simple-code-editor": "^0.13.1"
+    "react-simple-code-editor": "^0.13.1",
+    "react-tiny-popover": "^8.0.4"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.23.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ dependencies:
   '@miksu/prettier':
     specifier: ^1.18.6
     version: 1.18.6(@angular/compiler@7.2.16)(remark-parse@5.0.0)(yaml@1.10.2)
-  '@miksu/react-tiny-popover':
-    specifier: ^3.5.1
-    version: 3.5.1(react-dom@18.2.0)(react@18.2.0)
   copy-to-clipboard:
     specifier: ^3.3.3
     version: 3.3.3
@@ -47,6 +44,9 @@ dependencies:
   react-simple-code-editor:
     specifier: ^0.13.1
     version: 0.13.1(react-dom@18.2.0)(react@18.2.0)
+  react-tiny-popover:
+    specifier: ^8.0.4
+    version: 8.0.4(react-dom@18.2.0)(react@18.2.0)
 
 devDependencies:
   '@babel/preset-typescript':
@@ -1432,18 +1432,6 @@ packages:
       - yaml
     dev: false
 
-  /@miksu/react-tiny-popover@3.5.1(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-YSpc7wznyAzQdkQhrLwRNTvLX96swskKvWTNGkilFB2MyC6E0xMem4EtX93DYXHK0vslhpYMtqbjcAWQcLhZeQ==}
-    peerDependencies:
-      react: ^15.6.1 || ^16.0.0
-      react-dom: ^15.6.1 || ^16.0.0
-    dependencies:
-      '@types/underscore': 1.11.15
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      underscore: 1.13.6
-    dev: false
-
   /@mswjs/cookies@1.1.0:
     resolution: {integrity: sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==}
     engines: {node: '>=18'}
@@ -1899,10 +1887,6 @@ packages:
   /@types/statuses@2.0.4:
     resolution: {integrity: sha512-eqNDvZsCNY49OAXB0Firg/Sc2BgoWsntsLUdybGFOhAfCD6QJ2n9HXUIHGqt5qjrxmMv4wS8WLAw43ZkKcJ8Pw==}
     dev: true
-
-  /@types/underscore@1.11.15:
-    resolution: {integrity: sha512-HP38xE+GuWGlbSRq9WrZkousaQ7dragtZCruBVMi0oX1migFZavZ3OROKHSkNp/9ouq82zrWtZpg18jFnVN96g==}
-    dev: false
 
   /@types/unist@2.0.10:
     resolution: {integrity: sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==}
@@ -6907,6 +6891,16 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
+  /react-tiny-popover@8.0.4(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-pn0Y/G0gyMdYTBEWSKCCnaZsXAa54PkfnRE4fnMM5633SSClYrXxwXKc6vPYgJ9shLatGginxMjnhXq6guZmng==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
   /react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
     engines: {node: '>=0.10.0'}
@@ -8006,10 +8000,6 @@ packages:
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
     dev: true
-
-  /underscore@1.13.6:
-    resolution: {integrity: sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==}
-    dev: false
 
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}

--- a/src/ui/error.tsx
+++ b/src/ui/error.tsx
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 import * as React from "react";
-import Popover from "@miksu/react-tiny-popover";
+import { Popover } from "react-tiny-popover";
 import { formatBabelError, frameError, getStyles } from "../utils";
 import type { TErrorProps } from "../types";
 
@@ -17,7 +17,7 @@ const PopupError: React.FC<{ enabled: boolean; children: React.ReactNode }> = ({
   return (
     <Popover
       isOpen={enabled}
-      position={"bottom"}
+      positions={"bottom"}
       content={<div>{children}</div>}
     >
       <div />

--- a/src/ui/knob.tsx
+++ b/src/ui/knob.tsx
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 import * as React from "react";
-import Popover from "@miksu/react-tiny-popover";
+import { Popover } from "react-tiny-popover";
 import type { TPropValue, TImportsConfig } from "../types";
 import Error from "./error";
 import Editor from "./editor";
@@ -56,11 +56,11 @@ const Label: React.FC<{
   return (
     <Popover
       isOpen={Boolean(isHover)}
-      position={"top"}
+      positions={"top"}
       content={<div>{tooltip}</div>}
+      ref={hoverRef as any}
     >
       <label
-        ref={hoverRef as any}
         style={{
           fontWeight: 500,
           lineHeight: "20px",
@@ -83,11 +83,11 @@ const BooleanKnob: React.FC<{
   return (
     <Popover
       isOpen={Boolean(isHover)}
-      position={"top"}
+      positions={"top"}
       content={<div>{tooltip}</div>}
+      ref={hoverRef as any}
     >
       <div
-        ref={hoverRef as any}
         style={{
           display: "flex",
           alignItems: "center",


### PR DESCRIPTION
We use `npm` and React 17 in our project, but `@miksu/react-tiny-popover@3.5.1` adds React 16 and causes errors due to multiple React versions at runtime. So we had to add aliases for `react` and `react-dom` to the Webpack configuration. It would be nice if packages could work without them.

```sh
├── react-dom@17.0.2
└─┬ react-view@3.0.0
  ├─┬ @miksu/react-tiny-popover@3.5.1
  │ └── react-dom@16.14.0
  └─┬ react-simple-code-editor@0.13.1
    └── react-dom@17.0.2 deduped
```

This PR replaces `@miksu/react-tiny-popover` with the latest `react-tiny-popover` package.

Also, the contribution guidelines seem to be out of date, so I've replaced the `yarn` commands with ones I used but would appreciate feedback on this.

Thanks for the nice library!

